### PR TITLE
express upgrade to latest v4

### DIFF
--- a/lib/munin-server.js
+++ b/lib/munin-server.js
@@ -4,13 +4,14 @@
 // config should contain 'statsPath' and 'statsPort'
 module.exports = function(config, statsHandler) {
   var express = require('express');
+  var favicon = require('serve-favicon');
   var server = express();
 
   if (typeof config.statsPath === 'undefined') {
     throw new Error("Config is missing 'statsPath'");
   }
   
-  server.use(express.favicon());    // don't dump graphs when browser requests!
+  server.use(favicon());    // don't dump graphs when browser requests!
   
   // get list of available graphs
   server.get(config.statsPath + '/graphs', function(req, res) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "request": "~2.9.202",
     "underscore": "~1.3.3",
-    "express": "~3.2.6"
+    "express": "~4.14.0",
+    "serve-favicon": "~2.3.2"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
upgrades express to v4.14.0
required replacement of 'favicon' middleware with independent 'serve-favicon' equivalent.

- http://expressjs.com/en/guide/migrating-4.html#core-changes
- https://github.com/expressjs/serve-favicon